### PR TITLE
Do forward matching by default

### DIFF
--- a/src/lib/main.ts
+++ b/src/lib/main.ts
@@ -110,7 +110,7 @@ export class Fzf<U> {
       const match = fuzzyMatchV2(
         caseSensitive,
         this.opts.normalize,
-        false,
+        true,
         item,
         runes,
         true,


### PR DESCRIPTION
If `forward` is `false` then for v1 algo for query "aaa" it'll match "aaaaaaa"  as "aaaa**aaa**". This is certainly incorrect as a default behavior.