### PR TITLE
feat: flatten items of list returned from `fzf.find`

### DIFF
--- a/src/lib/main.ts
+++ b/src/lib/main.ts
@@ -64,9 +64,8 @@ const defaultOpts: Options<any> = {
   algo: "v2",
 };
 
-export interface FzfResultItem<U = string> {
+export interface FzfResultEntry<U = string> extends Result {
   item: U;
-  result: Result;
   positions: number[] | null;
 }
 
@@ -81,7 +80,7 @@ export class Fzf<U> {
   private runesList: Rune[][];
   private items: U[];
   private readonly opts: Options<U>;
-  private cache: Record<query, FzfResultItem<U>[]> = {};
+  private cache: Record<query, FzfResultEntry<U>[]> = {};
   private algoFn: AlgoFn;
 
   constructor(list: U[], ...optionsTuple: OptionsTuple<U>) {
@@ -91,7 +90,7 @@ export class Fzf<U> {
     this.algoFn = this.opts.algo === "v2" ? fuzzyMatchV2 : fuzzyMatchV1;
   }
 
-  find = (query: string): FzfResultItem<U>[] => {
+  find = (query: string): FzfResultEntry<U>[] => {
     let caseSensitive = false;
     switch (this.opts.casing) {
       case "smart-case":
@@ -126,13 +125,13 @@ export class Fzf<U> {
         true,
         slab
       );
-      return { item: this.items[index], result: match[0], positions: match[1] };
+      return { item: this.items[index], ...match[0], positions: match[1] };
     };
-    const thresholdFilter = (v: FzfResultItem<U>) => v.result.score !== 0;
+    const thresholdFilter = (v: FzfResultEntry<U>) => v.score !== 0;
     let result = this.runesList.map(getResult).filter(thresholdFilter);
 
-    const descScoreSorter = (a: FzfResultItem<U>, b: FzfResultItem<U>) =>
-      b.result.score - a.result.score;
+    const descScoreSorter = (a: FzfResultEntry<U>, b: FzfResultEntry<U>) =>
+      b.score - a.score;
     result.sort(descScoreSorter);
 
     if (Number.isFinite(this.opts.maxResultItems)) {

--- a/src/views/basic.tsx
+++ b/src/views/basic.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 
-import { Fzf, FzfResultItem } from "../lib/main";
+import { Fzf, FzfResultEntry } from "../lib/main";
 import { HighlightChars } from "../components/highlight-chars";
 import wordList from "../lists/words.json";
 import dateFnDirList from "../lists/date-fns-repo-folders.json";
@@ -15,7 +15,7 @@ let fzf = new Fzf(wordList, { ...options, casing: "case-insensitive" });
 export function Basic() {
   const [input, setInput] = useState("");
 
-  const [entries, setEntries] = useState<FzfResultItem[]>([]);
+  const [entries, setEntries] = useState<FzfResultEntry[]>([]);
 
   const handleInputChange = (input: string) => {
     setInput(input);
@@ -98,7 +98,7 @@ export function Basic() {
                   highlightIndices={entry.positions ?? []}
                 />
                 <span className="text-sm pl-4 italic text-gray-400">
-                  {entry.result.score}
+                  {entry.score}
                 </span>
               </li>
             ))}

--- a/src/views/custom.tsx
+++ b/src/views/custom.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 
 import { HighlightChars } from "../components/highlight-chars";
-import { Fzf, FzfResultItem } from "../lib/main";
+import { Fzf, FzfResultEntry } from "../lib/main";
 
 interface Stuff {
   id: string;
@@ -23,7 +23,7 @@ const fzf = new Fzf(list, {
 export function Custom() {
   const [input, setInput] = useState("");
 
-  const [entries, setEntries] = useState<FzfResultItem<Stuff>[]>([]);
+  const [entries, setEntries] = useState<FzfResultEntry<Stuff>[]>([]);
 
   const handleInputChange = (input: string) => {
     setInput(input);
@@ -57,7 +57,7 @@ export function Custom() {
                   highlightIndices={entry.positions ?? []}
                 />
                 <span className="text-sm pl-4 italic text-gray-400">
-                  {entry.result.score}
+                  {entry.score}
                 </span>
               </li>
             ))}

--- a/src/views/docs.mdx
+++ b/src/views/docs.mdx
@@ -131,9 +131,8 @@ const entry = entries[0];
 
 Each `entry` contains:
 - `item` - Original item that you send in the `list`.
-- `result`:
-  - `start` - number - Start index where the item is matched.
-  - `end` - number - End index + 1 where the item is matched.
-  - `score` - number - Higher the score, closest the item is matched to the query.
+- `start` - number - Start index where the item is matched.
+- `end` - number - End index + 1 where the item is matched.
+- `score` - number - Higher the score, closest the item is matched to the query.
 - `positions` - Indices of the characters that were matched in the item.
 


### PR DESCRIPTION
This makes items in the list coming from `fzf.find` be flatten. In other words, instead of accessing `entry.result.score`, one now will be able to use `entry.score`. This is partly done so that the word "result" itself can't be misinterpreted with something else. 