### PR TITLE
feat: make normalize true by default

### DIFF
--- a/src/lib/main.ts
+++ b/src/lib/main.ts
@@ -60,7 +60,7 @@ const defaultOpts: Options<any> = {
   maxResultItems: Infinity,
   selector: (v) => v,
   casing: "smart-case",
-  normalize: false,
+  normalize: true,
   algo: "v2",
 };
 

--- a/src/views/docs.mdx
+++ b/src/views/docs.mdx
@@ -115,7 +115,7 @@ Find a [working example](basic) for this and its [sourcecode](https://github.com
 - `maxResultItems?` - number, defaults to `Infinity` - If `maxResultItems` is 32, top 32 items that matches your query will be returned. By default all matched items are returned.
 - `selector?` - function, defaults to `v => v` - For each item in the list, target a specific property of the item to search for. This becomes a required option to pass when `list` is composed of items other than strings.
 - `casing?` - string, defaults to `"smart-case"`, accepts `"smart-case" | "case-sensitive" | "case-insensitive"` - Defines what type of case sensitive search you want.
-- `normalize?` - boolean, defaults to `false` - If true, FZF will try to remove diacritics from list items. This is useful if the list contains items with diacritics but you want to query with plain A-Z letters. For example, Zoë will be converted to Zoe.
+- `normalize?` - boolean, defaults to `true` - If true, FZF will try to remove diacritics from list items. This is useful if the list contains items with diacritics but you want to query with plain A-Z letters. For example, Zoë will be converted to Zoe.
 - `algo` - string, defaults to "v2", accepts `"v1" | "v2"` - Select which version of fuzzy algo you want to use. Refer to [this explanation](https://github.com/junegunn/fzf/blob/4c9cab3f8ae7b55f7124d7c3cf7ac6b4cc3db210/src/algo/algo.go#L5) to see the differences.
 
 ### `fzf.find(query)`


### PR DESCRIPTION
From https://github.com/kentcdodds/match-sorter#keepdiacritics-boolean

> By default, match-sorter will strip diacritics before doing any comparisons. This is the default because it makes the most sense from a UX perspective.

This makes sense to me too. 