### PR TITLE
perf: use direct assignments instead of spread

### DIFF
--- a/src/lib/main.ts
+++ b/src/lib/main.ts
@@ -130,7 +130,13 @@ export class Fzf<U> {
         true,
         slab
       );
-      return { item: this.items[index], ...match[0], positions: match[1] };
+      return {
+        item: this.items[index],
+        positions: match[1],
+        start: match[0].start,
+        end: match[0].end,
+        score: match[0].score,
+      };
     };
     const thresholdFilter = (v: FzfResultEntry<U>) => v.score !== 0;
     let result = this.runesList.map(getResult).filter(thresholdFilter);

--- a/src/lib/runes.ts
+++ b/src/lib/runes.ts
@@ -2,6 +2,9 @@ import { Int32 } from "./numerics";
 
 export type Rune = Int32;
 
+// This fn should give Int32[] not number[] but this is still okay in current
+// state as not many times a rune array is intended to be subarray-ed in the
+// code.
 export const strToRunes = (str: string) =>
   str.split("").map((s) => s.codePointAt(0)!);
 export const runesToStr = (runes: Rune[]) =>


### PR DESCRIPTION
Spreading objects are transpiled (on build) into a form that affects perf in V8 
but not in Gecko.