### PR TITLE
docs: better versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ dist-ssr
 coverage
 
 # Old docs generated on build
-src/docs/views/old-docs
+src/docs/old-docs

--- a/scripts/fill-with-old-docs.js
+++ b/scripts/fill-with-old-docs.js
@@ -34,6 +34,12 @@ const writeFile = (verMajor, verMinor) => {
     `git worktree add -f src/docs/old-docs/${verStr} ${nextCommitHash}^`,
     { silent: true }
   );
+
+  shell.rm(
+    "-r",
+    `src/docs/old-docs/${verStr}/vite*`,
+    `src/docs/old-docs/${verStr}/src/docs/typings`
+  );
 };
 
 for (let i = currVerMajor; i >= Math.max(0, currVerMajor - 2); i--) {

--- a/scripts/fill-with-old-docs.js
+++ b/scripts/fill-with-old-docs.js
@@ -30,10 +30,8 @@ const writeFile = (verMajor, verMinor) => {
       .stdout
   )["version"];
 
-  shell.mkdir("src/docs/old-docs/" + verStr);
-
   shell.exec(
-    `git --work-tree=src/docs/old-docs/${verStr} checkout ${nextCommitHash}^ -- src`
+    `git worktree add -f src/docs/old-docs/${verStr} ${nextCommitHash}^`
   );
 };
 

--- a/scripts/fill-with-old-docs.js
+++ b/scripts/fill-with-old-docs.js
@@ -8,11 +8,49 @@ shell.rm("-r", "src/docs/old-docs");
 shell.mkdir("src/docs/old-docs");
 shell.touch("src/docs/old-docs/.gitkeep");
 
-const writeFile = (verMajor, verMinor) => {
-  if (verMajor === 0 && verMinor <= 3) {
-    console.log(
-      `v${verMajor}.${verMinor} is incompatible with the current docs structure. Skipping...`
+const fillLegacyDocs = (verMajor, verMinor) => {
+  const nextCommitHash = shell
+    .exec(
+      `git log -S '"version": "${verMajor}.${verMinor}' --oneline -n 1 --branches HEAD -- package.json`,
+      {
+        silent: true,
+      }
+    )
+    .stdout.split(" ")[0];
+
+  const verStr = JSON.parse(
+    shell.exec(`git show ${nextCommitHash}^:./package.json`, { silent: true })
+      .stdout
+  )["version"];
+
+  const fileContent = shell.exec(
+    `git show ${nextCommitHash}^:./src/views/docs.mdx`,
+    { silent: true }
+  ).stdout;
+
+  const pkgFileContent = shell.exec(
+    `git show ${nextCommitHash}^:./package.json`,
+    { silent: true }
+  ).stdout;
+
+  if (fileContent !== "") {
+    shell.mkdir("-p", `src/docs/old-docs/${verStr}/src/docs`);
+    shell
+      .ShellString(fileContent)
+      .to(`src/docs/old-docs/${verStr}/src/docs/docs.mdx`);
+    shell
+      .ShellString(pkgFileContent)
+      .to(`src/docs/old-docs/${verStr}/package.json`);
+    shell.cp(
+      "scripts/legacy-app-routes.tsx",
+      `src/docs/old-docs/${verStr}/src/docs/app-routes.tsx`
     );
+  }
+};
+
+const fillDocs = (verMajor, verMinor) => {
+  if (verMajor === 0 && verMinor <= 3) {
+    fillLegacyDocs(verMajor, verMinor);
     return;
   }
 
@@ -45,7 +83,7 @@ const writeFile = (verMajor, verMinor) => {
 for (let i = currVerMajor; i >= Math.max(0, currVerMajor - 2); i--) {
   if (i === currVerMajor) {
     for (let j = currVerMinor - 1; j >= Math.max(0, currVerMinor - 2); j--) {
-      writeFile(i, j);
+      fillDocs(i, j);
     }
   } else {
     const nextCommitHash = shell
@@ -64,7 +102,7 @@ for (let i = currVerMajor; i >= Math.max(0, currVerMajor - 2); i--) {
     const verMinor = parseInt(verStr.split(".")[1], 10);
 
     for (let j = verMinor; j >= Math.max(0, verMinor - 2); j--) {
-      writeFile(i, j);
+      fillDocs(i, j);
     }
   }
 }

--- a/scripts/fill-with-old-docs.js
+++ b/scripts/fill-with-old-docs.js
@@ -4,11 +4,11 @@ const currVerStr = require("../package.json").version;
 const currVerMajor = parseInt(currVerStr.split(".")[0], 10);
 const currVerMinor = parseInt(currVerStr.split(".")[1], 10);
 
-shell.rm("-r", "src/docs/views/old-docs");
-shell.mkdir("src/docs/views/old-docs");
-shell.touch("src/docs/views/old-docs/.gitkeep");
+shell.rm("-r", "src/docs/old-docs");
+shell.mkdir("src/docs/old-docs");
+shell.touch("src/docs/old-docs/.gitkeep");
 
-const writeFile = (verMajor, verMinor) => {
+const writeFileLegacy = (verMajor, verMinor) => {
   const nextCommitHash = shell
     .exec(
       `git log -S '"version": "${verMajor}.${verMinor}' --oneline -n 1 --branches HEAD -- package.json`,
@@ -31,6 +31,33 @@ const writeFile = (verMajor, verMinor) => {
   if (fileContent !== "") {
     shell.ShellString(fileContent).to(`src/docs/views/old-docs/${verStr}.mdx`);
   }
+};
+
+const writeFile = (verMajor, verMinor) => {
+  if (verMajor === 0 && verMinor <= 3) {
+    console.log("nope won't write it", verMajor, verMinor);
+    // writeFileLegacy(verMajor, verMinor);
+  }
+
+  const nextCommitHash = shell
+    .exec(
+      `git log -S '"version": "${verMajor}.${verMinor}' --oneline -n 1 --branches HEAD -- package.json`,
+      {
+        silent: true,
+      }
+    )
+    .stdout.split(" ")[0];
+
+  const verStr = JSON.parse(
+    shell.exec(`git show ${nextCommitHash}^:./package.json`, { silent: true })
+      .stdout
+  )["version"];
+
+  shell.mkdir("src/docs/old-docs/" + verStr);
+
+  shell.exec(
+    `git --work-tree=src/docs/old-docs/${verStr} checkout ${nextCommitHash}^ -- src`
+  );
 };
 
 for (let i = currVerMajor; i >= Math.max(0, currVerMajor - 2); i--) {

--- a/scripts/fill-with-old-docs.js
+++ b/scripts/fill-with-old-docs.js
@@ -8,35 +8,12 @@ shell.rm("-r", "src/docs/old-docs");
 shell.mkdir("src/docs/old-docs");
 shell.touch("src/docs/old-docs/.gitkeep");
 
-const writeFileLegacy = (verMajor, verMinor) => {
-  const nextCommitHash = shell
-    .exec(
-      `git log -S '"version": "${verMajor}.${verMinor}' --oneline -n 1 --branches HEAD -- package.json`,
-      {
-        silent: true,
-      }
-    )
-    .stdout.split(" ")[0];
-
-  const verStr = JSON.parse(
-    shell.exec(`git show ${nextCommitHash}^:./package.json`, { silent: true })
-      .stdout
-  )["version"];
-
-  const fileContent = shell.exec(
-    `git show ${nextCommitHash}^:./src/docs/views/docs.mdx`,
-    { silent: true }
-  ).stdout;
-
-  if (fileContent !== "") {
-    shell.ShellString(fileContent).to(`src/docs/views/old-docs/${verStr}.mdx`);
-  }
-};
-
 const writeFile = (verMajor, verMinor) => {
   if (verMajor === 0 && verMinor <= 3) {
-    console.log("nope won't write it", verMajor, verMinor);
-    // writeFileLegacy(verMajor, verMinor);
+    console.log(
+      `v${verMajor}.${verMinor} is incompatible with the current docs structure. Skipping...`
+    );
+    return;
   }
 
   const nextCommitHash = shell

--- a/scripts/fill-with-old-docs.js
+++ b/scripts/fill-with-old-docs.js
@@ -31,7 +31,8 @@ const writeFile = (verMajor, verMinor) => {
   )["version"];
 
   shell.exec(
-    `git worktree add -f src/docs/old-docs/${verStr} ${nextCommitHash}^`
+    `git worktree add -f src/docs/old-docs/${verStr} ${nextCommitHash}^`,
+    { silent: true }
   );
 };
 

--- a/scripts/legacy-app-routes.tsx
+++ b/scripts/legacy-app-routes.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Routes, Route } from "react-router-dom";
+
+import Docs from "./docs.mdx";
+
+const AppRoutes = () => {
+  return (
+    <Routes>
+      <Route element={<Docs />} />
+      <Route path="*" element={<div>not found</div>} />
+    </Routes>
+  );
+};
+
+export default AppRoutes;

--- a/src/docs/app-routes.tsx
+++ b/src/docs/app-routes.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Routes, Route } from "react-router-dom";
+
+import Docs from "./views/docs.mdx";
+import { Basic } from "./views/basic";
+import { Custom } from "./views/custom";
+
+const AppRoutes = () => {
+  return (
+    <Routes>
+      <Route element={<Docs />} />
+      <Route path="basic" element={<Basic />} />
+      <Route path="custom" element={<Custom />} />
+      <Route path="*" element={<div>not found</div>} />
+    </Routes>
+  );
+};
+
+export default AppRoutes;

--- a/src/docs/app.tsx
+++ b/src/docs/app.tsx
@@ -1,5 +1,10 @@
-import React, { forwardRef, isValidElement } from "react";
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import React, { forwardRef, isValidElement, version } from "react";
+import {
+  BrowserRouter as Router,
+  Navigate,
+  Route,
+  Routes,
+} from "react-router-dom";
 import { MDXProvider } from "@mdx-js/react";
 // @ts-ignore missing types
 import preval from "preval.macro";
@@ -7,11 +12,9 @@ import preval from "preval.macro";
 import "./app.css";
 
 import { CodeBlock } from "./components/code-block";
-import Docs from "./views/docs.mdx";
-import { Basic } from "./views/basic";
-import { Custom } from "./views/custom";
 import linkIconSrc from "./assets/link.svg";
 import { DocsVersions } from "./views/docs-versions";
+import AppRoutes from "./app-routes";
 import "./utils/expose";
 
 function getAnchor(text: string) {
@@ -20,6 +23,12 @@ function getAnchor(text: string) {
     .replace(/[ \(\.]/g, "-")
     .replace(/[^a-z0-9-]/g, "");
 }
+
+const {
+  fileVersions: docsVersions,
+}: {
+  fileVersions: string[];
+} = preval`module.exports = require('./old-docs-list')`;
 
 interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {}
 
@@ -84,16 +93,12 @@ const mdxComponents = {
   ),
 };
 
-const {
-  fileVersions: docsVersions,
-}: {
-  fileVersions: string[];
-} = preval`module.exports = require('./old-docs-list')`;
-
 const oldDocs = docsVersions.map((version) => {
   return {
     version,
-    Component: React.lazy(() => import(`./views/old-docs/${version}.mdx`)),
+    Component: React.lazy(
+      () => import(`./old-docs/${version}/src/docs/app-routes.tsx`)
+    ),
   };
 });
 
@@ -103,9 +108,11 @@ export function App() {
       <MDXProvider components={mdxComponents}>
         <Router>
           <Routes>
-            <Route path="/" element={<Docs />} />
-            <Route path="basic" element={<Basic />} />
-            <Route path="custom" element={<Custom />} />
+            <Route path="/">
+              <Navigate to="current" replace />
+            </Route>
+            <Route path="current/*" element={<AppRoutes />} />
+            <Route path="*" element={<div>not found</div>} />
             <Route
               path="docs/versions"
               element={<DocsVersions versions={docsVersions} />}
@@ -127,7 +134,6 @@ export function App() {
                 />
               );
             })}
-            <Route path="*" element={<div>not found</div>} />
           </Routes>
         </Router>
       </MDXProvider>

--- a/src/docs/app.tsx
+++ b/src/docs/app.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, isValidElement, version } from "react";
+import React, { forwardRef, isValidElement } from "react";
 import {
   BrowserRouter as Router,
   Navigate,
@@ -109,19 +109,19 @@ export function App() {
         <Router>
           <Routes>
             <Route path="/">
-              <Navigate to="current" replace />
+              <Navigate to="versions/latest" replace />
             </Route>
-            <Route path="current/*" element={<AppRoutes />} />
+            <Route path="versions/latest/*" element={<AppRoutes />} />
             <Route path="*" element={<div>not found</div>} />
             <Route
-              path="docs/versions"
+              path="versions"
               element={<DocsVersions versions={docsVersions} />}
             />
             {oldDocs.map((v) => {
               return (
                 <Route
                   key={v.version}
-                  path={`docs/versions/${v.version.replaceAll(".", "-")}/*`}
+                  path={`versions/${v.version.replaceAll(".", "-")}/*`}
                   element={
                     <React.Suspense
                       fallback={

--- a/src/docs/app.tsx
+++ b/src/docs/app.tsx
@@ -109,19 +109,19 @@ export function App() {
         <Router>
           <Routes>
             <Route path="/">
-              <Navigate to="versions/latest" replace />
+              <Navigate to="docs/latest" replace />
             </Route>
-            <Route path="versions/latest/*" element={<AppRoutes />} />
+            <Route path="docs/latest/*" element={<AppRoutes />} />
             <Route path="*" element={<div>not found</div>} />
             <Route
-              path="versions"
+              path="docs"
               element={<DocsVersions versions={docsVersions} />}
             />
             {oldDocs.map((v) => {
               return (
                 <Route
                   key={v.version}
-                  path={`versions/${v.version.replaceAll(".", "-")}/*`}
+                  path={`docs/${v.version.replaceAll(".", "-")}/*`}
                   element={
                     <React.Suspense
                       fallback={

--- a/src/docs/app.tsx
+++ b/src/docs/app.tsx
@@ -121,7 +121,7 @@ export function App() {
               return (
                 <Route
                   key={v.version}
-                  path={`docs/versions/${v.version.replaceAll(".", "-")}`}
+                  path={`docs/versions/${v.version.replaceAll(".", "-")}/*`}
                   element={
                     <React.Suspense
                       fallback={

--- a/src/docs/old-docs-list.js
+++ b/src/docs/old-docs-list.js
@@ -2,7 +2,7 @@ const path = require("path");
 const glob = require("glob");
 
 let fileVersions = glob
-  .sync("./src/docs/views/old-docs/*.mdx")
+  .sync("./src/docs/old-docs/*/")
   .map((v) => path.parse(v).name);
 
 module.exports = { fileVersions };

--- a/src/docs/old-docs-list.js
+++ b/src/docs/old-docs-list.js
@@ -3,6 +3,6 @@ const glob = require("glob");
 
 let fileVersions = glob
   .sync("./src/docs/old-docs/*/")
-  .map((v) => path.parse(v).name);
+  .map((v) => path.parse(v).base);
 
 module.exports = { fileVersions };

--- a/src/docs/views/docs.mdx
+++ b/src/docs/views/docs.mdx
@@ -1,10 +1,14 @@
 import { Link } from "react-router-dom";
+import pkg from '../../../package.json'
 
 # FZF for JavaScript (Preview)
 
 <span className="docs-hidden"><i>If you are reading this file on GitHub, we'll suggest to read it on <a href="https://fzf.netlify.app">documentation website</a> instead.</i></span>
 
-<Link to="basic">Demo</Link> · <a href="https://github.com/ajitid/fzf-for-js">GitHub</a> · <a href="https://www.npmjs.com/package/fzf">NPM</a>
+<div className="flex justify-between flex-wrap">
+  <div><Link to="basic">Demo</Link> · <a href="https://github.com/ajitid/fzf-for-js">GitHub</a> · <a href="https://www.npmjs.com/package/fzf">NPM</a></div>
+  <div>Viewing for v{pkg.version} (<Link to="/versions">see others</Link>)</div>
+</div>
 
 [FZF (stylised as fzf)](https://github.com/junegunn/fzf) is a command line based fuzzy finder built using Golang. A fuzzy finder allows you to type few characters that appear in a string that you are looking for and get that string from a list of strings quickly. FZF for JavaScript ports FZF's algorithm to JavaScript so that it can be used in the browser. However it doesn't tries to be as performant as its Golang's counterpart, so while this package can work in Node.JS, you are still better off with Golang version for CLI usage.
 

--- a/src/docs/views/docs.mdx
+++ b/src/docs/views/docs.mdx
@@ -7,7 +7,7 @@ import pkg from '../../../package.json'
 
 <div className="flex justify-between flex-wrap">
   <div><Link to="basic">Demo</Link> · <a href="https://github.com/ajitid/fzf-for-js">GitHub</a> · <a href="https://www.npmjs.com/package/fzf">NPM</a></div>
-  <div>Viewing for v{pkg.version} (<Link to="/versions">see others</Link>)</div>
+  <div>Viewing for v{pkg.version} (<Link to="/docs">see others</Link>)</div>
 </div>
 
 [FZF (stylised as fzf)](https://github.com/junegunn/fzf) is a command line based fuzzy finder built using Golang. A fuzzy finder allows you to type few characters that appear in a string that you are looking for and get that string from a list of strings quickly. FZF for JavaScript ports FZF's algorithm to JavaScript so that it can be used in the browser. However it doesn't tries to be as performant as its Golang's counterpart, so while this package can work in Node.JS, you are still better off with Golang version for CLI usage.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  purge: ["./index.html", "./src/**/*.{vue,js,ts,jsx,tsx}"],
+  purge: ["./index.html", "./src/**/*.{vue,js,ts,jsx,tsx,mdx}"],
   darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {


### PR DESCRIPTION
With this PR, docs for newer releases will hold the whole source code for that version, not just the doc file. This means that the examples and other dynamic content embedded in doc will continue to work.

This PR has a concerning side effect. For it to work properly, we need to have a linear history in branches. This might be okay for `dev` branch but not for `stable-releases`.

Even without this branch, I cannot think of a way to predictably handle both merge commits and the squashed ones.