### PR TITLE
chore: don't build docs if version < 0.3

### DIFF
--- a/scripts/fill-with-old-docs.js
+++ b/scripts/fill-with-old-docs.js
@@ -50,6 +50,8 @@ const fillLegacyDocs = (verMajor, verMinor) => {
 
 const fillDocs = (verMajor, verMinor) => {
   if (verMajor === 0 && verMinor <= 3) {
+    if (verMinor < 3) return;
+
     fillLegacyDocs(verMajor, verMinor);
     return;
   }


### PR DESCRIPTION
Versions before 0.3 existed before the public preview release was made. They are already gone, the docs are needed to be too.