### PR TITLE
fix: merge large result lists safely

### DIFF
--- a/src/lib/__tests__/main.ts
+++ b/src/lib/__tests__/main.ts
@@ -153,7 +153,7 @@ test("sort", () => {
 });
 
 test("large resultset", () => {
-  const list = new Array(1000000).fill("hello")
+  const list = new Array(200000).fill("hello")
   const fzf = new Fzf(list)
   expect(fzf.find("he").length).toBe(list.length);
 });

--- a/src/lib/__tests__/main.ts
+++ b/src/lib/__tests__/main.ts
@@ -153,7 +153,7 @@ test("sort", () => {
 });
 
 test("large resultset", () => {
-  const list = new Array(200000).fill("hello")
-  const fzf = new Fzf(list)
+  const list = new Array(200000).fill("hello");
+  const fzf = new Fzf(list);
   expect(fzf.find("he").length).toBe(list.length);
 });

--- a/src/lib/__tests__/main.ts
+++ b/src/lib/__tests__/main.ts
@@ -151,3 +151,9 @@ test("sort", () => {
     }
   }
 });
+
+test("large resultset", () => {
+  const list = new Array(1000000).fill("hello")
+  const fzf = new Fzf(list)
+  expect(fzf.find("he").length).toBe(list.length);
+});

--- a/src/lib/matchers.ts
+++ b/src/lib/matchers.ts
@@ -103,10 +103,10 @@ function getResultFromScoreMap<T>(
     .map((v) => parseInt(v, 10))
     .sort((a, b) => b - a);
 
-  const result: FzfResultItem<T>[] = [];
+  let result: FzfResultItem<T>[] = [];
 
   for (const score of scoresInDesc) {
-    result.push(...scoreMap[score]);
+    result = result.concat(scoreMap[score]);
     if (result.length >= limit) {
       break;
     }


### PR DESCRIPTION
`result.push(...scoreMap[score])` expands to a function call with `scoreMap[score].length` parameters, which breaks when `scoreMap[score].length` > max allowed parameters for a function (which supposedly is something around 65k).

This replaces the `result` array on each iteration. I was afraid that this might be a bit slower, but actually code is about 1% faster in my (very limited) tests. Memory usage is about 0.3% higher.