### PR TITLE
test: increase input list size for "large result set" test

### DIFF
--- a/src/lib/__tests__/main.ts
+++ b/src/lib/__tests__/main.ts
@@ -152,8 +152,8 @@ test("sort", () => {
   }
 });
 
-test("large resultset", () => {
-  const list = new Array(200000).fill("hello");
+test("large result set", () => {
+  const list = new Array(510000).fill("hello");
   const fzf = new Fzf(list);
   expect(fzf.find("he").length).toBe(list.length);
 });


### PR DESCRIPTION
This is a continuation of PR https://github.com/ajitid/fzf-for-js/pull/69. That PR should've been merged without modification which I didn't do. 

With code

```js
l = new Array(200000).fill("hello")
fn  = () => {}
fn(...l)
```

... there are few observations:
- Both JavaScriptCore (Webkit, Safari) and V8 (Blink, Chromium) cannot accept 200000 arguments in a function (they throw an error)
- SpiderMonkey (Gecko, Firefox) accepts 200000 args but throws an error when 510000 args are given

Safari and Chromium throw same error:

```
Uncaught RangeError: Maximum call stack size exceeded
```

Firefox shows a more readable error:

```
Uncaught RangeError: too many function arguments
```

These browsers used to have even lower limit https://stackoverflow.com/a/22747272/7683365. So while the accompanying code change is okay for now, it might result in false positive in the future. 