### PR TITLE
bugfix: standard fzf bylength sort means sort by trimmed length

### DIFF
--- a/src/lib/__tests__/main.ts
+++ b/src/lib/__tests__/main.ts
@@ -2,6 +2,7 @@ import "jest-expect-message";
 
 import { Fzf } from "../main";
 import { basicMatch, extendedMatch } from "../main";
+import {byLengthAsc} from "../tiebreakers";
 import { Options } from "../types";
 
 test("filtering in extended match", () => {
@@ -157,3 +158,8 @@ test("large result set", () => {
   const fzf = new Fzf(list);
   expect(fzf.find("he").length).toBe(list.length);
 });
+
+test("length tiebreaker trims length", () => {
+  const fzf = new Fzf(["aaaa", "  aaa", "  aa  ", "a      "], {tiebreakers: [byLengthAsc]})
+  expect(fzf.find("a").map(r => r.item)).toEqual(["a      ", "  aa  ", "  aaa", "aaaa"])
+})

--- a/src/lib/tiebreakers.ts
+++ b/src/lib/tiebreakers.ts
@@ -5,7 +5,7 @@ export function byLengthAsc<U>(
   b: FzfResultItem<U>,
   opts: Options<U>
 ): number {
-  return opts.selector(a.item).length - opts.selector(b.item).length;
+  return opts.selector(a.item).trim().length - opts.selector(b.item).trim().length;
 }
 
 export function byStartAsc<U>(


### PR DESCRIPTION
While doing the performance tests, I'm trying to see if all method at least return the same results. Here is one location where your code doesn't agree with `fzf`, as can be seen by running `echo "aaaa\n  aaa\n  aa  \na      " | fzf --filter a`.

The reason is that fzf sorts on trimmed length of the string ( see https://github.com/junegunn/fzf/blob/3f90fb42d8871920138ace9878502f22a4d91e85/src/result.go#L53 )

Unfortunately this test makes my code 10% slower -- this makes sense since the `trim()` is done for every compare (actually, this is also true for `opts.selector()` when it's not the identity function) -- probably one would like to move these to a place where they're only done once per string, but I'm assuming you'll have a better idea of where that is that I....