### PR TITLE
feat!: change tiebreaker's third argument to `selector`

### DIFF
--- a/src/docs/views/docs.mdx
+++ b/src/docs/views/docs.mdx
@@ -205,8 +205,8 @@ const results: FzfResultItem<Fruit>[] = fzf.find('ppya') // gives you back a pap
 This library has different defaults compared to FZF CLI. Get a behaviour similar to CLI with these options:
 
 ```js
-function byTrimmedLengthAsc(a, b, opts) {
-  return opts.selector(a.item).trim().length - opts.selector(b.item).trim().length;
+function byTrimmedLengthAsc(a, b, selector) {
+  return selector(a.item).trim().length - selector(b.item).trim().length;
 }
 
 const fzf = new Fzf(list, {
@@ -232,7 +232,7 @@ const fzf = new Fzf(list, {
 - `selector?` - function, defaults to `v => v` - For each item in the list, target a specific property of the item to search for. This becomes a required option to pass when `list` is composed of items other than strings.
 - `casing?` - string, defaults to `"smart-case"`, accepts `"smart-case" | "case-sensitive" | "case-insensitive"` - Defines what type of case sensitive search you want.
 - `normalize?` - boolean, defaults to `true` - If true, FZF will try to remove diacritics from list items. This is useful if the list contains items with diacritics but you want to query with plain A-Z letters. For example, Zoë will be converted to Zoe.
-- `tiebreakers?` - array, defaults to `[]` - A list of functions that decide sort order when the score is tied between two result entries. A tiebreaker is nothing but a compare function like the one you find in [JS Array sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) with an added third argument which is this `options` itself. First and second arguments are result entries that you receive from `fzf.find`. Note that tiebreakers can't be used if `sort=false`. This library ships with two tiebreakers - `byLengthAsc` and `byStartAsc`.
+- `tiebreakers?` - array, defaults to `[]` - A list of functions that decide sort order when the score is tied between two result entries. A tiebreaker is nothing but a compare function like the one you find in [JS Array sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) with an added third argument which is `options.selector`. First and second arguments are result entries that you receive from `fzf.find`. Note that tiebreakers can't be used if `sort=false`. This library ships with two tiebreakers - `byLengthAsc` and `byStartAsc`.
 - `sort?` - boolean, defaults to `true` - If true, result items will be sorted in descending order by their score. Otherwise, the items won't be sorted and tiebreakers won't be applied either; they will be returned in the same order that they were in the input list.
 - `fuzzy?` - string, defaults to `"v2"`, accepts `"v1" | "v2" | false` - Select which version of fuzzy algo you want to use. Refer to [this explanation](https://github.com/junegunn/fzf/blob/4c9cab3f8ae7b55f7124d7c3cf7ac6b4cc3db210/src/algo/algo.go#L5) to see the differences. If asssigned `false`, an exact match will be made instead of a fuzzy one.
 - `match?` - function, defaults to `basicMatch` - We provide two built-in functions, namely `basicMatch` and `extendedMatch`. If `extendedMatch` is used, you can add special patterns to narrow down your search. To read more about how it can be used, see [this section](https://github.com/junegunn/fzf/tree/7191ebb615f5d6ebbf51d598d8ec853a65e2274d#search-syntax). For a quick glance, see [this piece](https://github.com/junegunn/fzf/blob/764316a53d0eb60b315f0bbcd513de58ed57a876/src/pattern.go#L12-L19).

--- a/src/docs/views/docs.mdx
+++ b/src/docs/views/docs.mdx
@@ -205,13 +205,17 @@ const results: FzfResultItem<Fruit>[] = fzf.find('ppya') // gives you back a pap
 This library has different defaults compared to FZF CLI. Get a behaviour similar to CLI with these options:
 
 ```js
+function byTrimmedLengthAsc(a, b, opts) {
+  return opts.selector(a.item).trim().length - opts.selector(b.item).trim().length;
+}
+
 const fzf = new Fzf(list, {
   match: extendedMatch,
-  tiebreakers: [byLengthAsc]
+  tiebreakers: [byTrimmedLengthAsc]
 })
 ```
 
-Both `extendedMatch` and `byLengthAsc` are present in the library for you to import and use.
+`extendedMatch` is present in the library for you to import and use.
 
 ### Notes
 

--- a/src/lib/finder.ts
+++ b/src/lib/finder.ts
@@ -65,10 +65,12 @@ export class Finder<L extends ReadonlyArray<any>> {
       this.opts.match.bind(this)(query);
 
     if (this.opts.sort) {
+      const { selector } = this.opts;
+
       result.sort((a, b) => {
         if (a.score === b.score) {
           for (const tiebreaker of this.opts.tiebreakers) {
-            const diff = tiebreaker(a, b, this.opts);
+            const diff = tiebreaker(a, b, selector);
             if (diff !== 0) {
               return diff;
             }

--- a/src/lib/tiebreakers.ts
+++ b/src/lib/tiebreakers.ts
@@ -3,9 +3,9 @@ import type { FzfResultItem, Options } from "./types";
 export function byLengthAsc<U>(
   a: FzfResultItem<U>,
   b: FzfResultItem<U>,
-  opts: Options<U>
+  selector: Options<U>["selector"]
 ): number {
-  return opts.selector(a.item).length - opts.selector(b.item).length;
+  return selector(a.item).length - selector(b.item).length;
 }
 
 export function byStartAsc<U>(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,7 +11,7 @@ export interface FzfResultItem<U = string> extends Result {
 export type Tiebreaker<U> = (
   a: FzfResultItem<U>,
   b: FzfResultItem<U>,
-  options: Options<U>
+  selector: Options<U>["selector"]
 ) => number;
 
 export interface Options<U> {
@@ -69,7 +69,7 @@ export interface Options<U> {
    * sort result entries when the score between two entries is tied.
    *
    * Consider a tiebreaker to be a [JS array sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
-   * compare function with an added third argument which is this `options` itself.
+   * compare function with an added third argument which is `options.selector`.
    *
    * If multiple tiebreakers are given, they are evaluated left to right until
    * one breaks the tie.
@@ -84,8 +84,8 @@ export interface Options<U> {
    *
    * @example
    * ```js
-   * function byLengthAsc(a, b, options) {
-   *   return options.selector(a.item).length - options.selector(b.item).length;
+   * function byLengthAsc(a, b, selector) {
+   *   return selector(a.item).length - selector(b.item).length;
    * }
    *
    * const fzf = new Fzf(list, { tiebreakers: [byLengthAsc] })


### PR DESCRIPTION
Originally `selector` was the third argument but it was changed to `options` due to issues in type inference.