### PR TITLE
docs: scroll URL's hash element into view

### DIFF
--- a/src/docs/app.tsx
+++ b/src/docs/app.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, isValidElement } from "react";
+import React from "react";
 import {
   BrowserRouter as Router,
   Navigate,
@@ -11,85 +11,17 @@ import preval from "preval.macro";
 
 import "./app.css";
 
-import { CodeBlock } from "./components/code-block";
-import linkIconSrc from "./assets/link.svg";
 import { DocsVersions } from "./views/docs-versions";
 import AppRoutes from "./app-routes";
 import Migrate from "./views/migrate.mdx";
 import "./utils/expose";
-
-function getAnchor(text: string) {
-  return text
-    .toLowerCase()
-    .replace(/[ \(\.]/g, "-")
-    .replace(/→/g, "to")
-    .replace(/[^a-z0-9-]/g, "");
-}
+import { mdxComponents } from "./utils/mdx-setup";
 
 const {
   fileVersions: docsVersions,
 }: {
   fileVersions: string[];
 } = preval`module.exports = require('./old-docs-list')`;
-
-interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {}
-
-const getHeading = (level: number) => {
-  const Heading = (props: HeadingProps, ref: React.Ref<HTMLHeadingElement>) => {
-    let anchor = getAnchor(
-      typeof props.children === "string" ? getAnchor(props.children) : ""
-    );
-    if (!anchor) {
-      if (isValidElement(props.children)) {
-        const elProps = props.children.props;
-        const children = elProps["children"];
-        if (typeof children === "string") {
-          anchor = getAnchor(children);
-        }
-      }
-    }
-
-    const link = `#${anchor}`;
-
-    return React.createElement(
-      `h${level}`,
-      {
-        id: anchor,
-        ref,
-      },
-      [
-        <a
-          key="1"
-          href={link}
-          className="heading-link"
-          style={{ textDecoration: "none" }}
-        >
-          {props.children}
-          <img
-            src={linkIconSrc}
-            className="w-5 inline-block ml-2"
-            style={{ marginTop: 0, marginBottom: 0 }}
-          />
-        </a>,
-      ]
-    );
-  };
-
-  return forwardRef(Heading);
-};
-
-const mdxComponents = {
-  wrapper: (props: any) => (
-    <div className="container mx-auto prose lg:max-w-3xl px-3 sm:px-0">
-      <main {...props} />
-    </div>
-  ),
-  code: CodeBlock as React.ComponentType<{ children: React.ReactNode }>,
-  // headings
-  ...Object.fromEntries(
-    [2, 3, 4].map((level) => ["h" + level, getHeading(level)])
-  ),
-};
 
 const oldDocs = docsVersions.map((version) => {
   return {

--- a/src/docs/utils/mdx-setup.tsx
+++ b/src/docs/utils/mdx-setup.tsx
@@ -1,0 +1,103 @@
+import React, {
+  forwardRef,
+  isValidElement,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import { mergeReferences } from "./merge-references";
+import { CodeBlock } from "../components/code-block";
+import linkIconSrc from "../assets/link.svg";
+
+function getAnchor(text: string) {
+  return text
+    .toLowerCase()
+    .replace(/[ \(\.]/g, "-")
+    .replace(/→/g, "to")
+    .replace(/[^a-z0-9-]/g, "");
+}
+
+interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {}
+
+const getHeading = (level: number) => {
+  const Heading = (props: HeadingProps, ref: React.Ref<HTMLHeadingElement>) => {
+    const elRef = useRef<HTMLHeadingElement>(null);
+    const mergedRefs = mergeReferences(ref, elRef);
+
+    const [anchor, setAnchor] = useState("");
+    useEffect(() => {
+      let anchor = getAnchor(
+        typeof props.children === "string" ? getAnchor(props.children) : ""
+      );
+      if (!anchor) {
+        if (isValidElement(props.children)) {
+          const elProps = props.children.props;
+          const children = elProps["children"];
+          if (typeof children === "string") {
+            anchor = getAnchor(children);
+          }
+        }
+      }
+
+      // eg. for h3, try to find h2 and combine to form the anchor
+      let headingEl = elRef.current;
+      if (level >= 3 && headingEl) {
+        let el: Node | null = headingEl;
+
+        const tagNameToFind = "H" + (level - 1);
+        while ((el = el.previousSibling)) {
+          if (el instanceof HTMLElement && el.tagName === tagNameToFind) {
+            const { textContent } = el;
+            if (!textContent) break;
+
+            anchor = getAnchor(textContent) + "-" + anchor;
+            break;
+          }
+        }
+      }
+
+      setAnchor(anchor);
+    }, []);
+
+    const link = `#${anchor}`;
+
+    return React.createElement(
+      `h${level}`,
+      {
+        id: anchor,
+        ref: mergedRefs,
+      },
+      [
+        <a
+          key="1"
+          href={link}
+          className="heading-link"
+          style={{ textDecoration: "none" }}
+        >
+          {props.children}
+          <img
+            src={linkIconSrc}
+            className="w-5 inline-block ml-2"
+            style={{ marginTop: 0, marginBottom: 0 }}
+          />
+        </a>,
+      ]
+    );
+  };
+
+  return forwardRef(Heading);
+};
+
+export const mdxComponents = {
+  wrapper: (props: any) => (
+    <div className="container mx-auto prose lg:max-w-3xl px-3 sm:px-0">
+      <main {...props} />
+    </div>
+  ),
+  code: CodeBlock as React.ComponentType<{ children: React.ReactNode }>,
+  // headings
+  ...Object.fromEntries(
+    [2, 3, 4].map((level) => ["h" + level, getHeading(level)])
+  ),
+};

--- a/src/docs/utils/mdx-setup.tsx
+++ b/src/docs/utils/mdx-setup.tsx
@@ -90,11 +90,18 @@ const getHeading = (level: number) => {
 };
 
 export const mdxComponents = {
-  wrapper: (props: any) => (
-    <div className="container mx-auto prose lg:max-w-3xl px-3 sm:px-0">
-      <main {...props} />
-    </div>
-  ),
+  wrapper: (props: any) => {
+    useEffect(() => {
+      const { hash } = window.location;
+      if (hash) document.querySelector(hash)?.scrollIntoView();
+    }, []);
+
+    return (
+      <div className="container mx-auto prose lg:max-w-3xl px-3 sm:px-0">
+        <main {...props} />
+      </div>
+    );
+  },
   code: CodeBlock as React.ComponentType<{ children: React.ReactNode }>,
   // headings
   ...Object.fromEntries(

--- a/src/docs/utils/merge-references.ts
+++ b/src/docs/utils/merge-references.ts
@@ -1,0 +1,32 @@
+import type { MutableRefObject } from 'react';
+
+type References<T extends HTMLElement = HTMLElement> =
+  | MutableRefObject<unknown>
+  | ((element: T | null) => void)
+  | undefined
+  | null;
+
+/**
+ * Utility function that let's you assign multiple references to a 'ref' prop
+ * @param refs list of MutableRefObject's and/or callbacks
+ */
+export function mergeReferences<T extends HTMLElement = HTMLElement>(
+  // Suppressing ESLint as the function assigns `MutableRefObject` a value.
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  ...references: References<T>[]
+) {
+  return (element: T | null) => {
+    for (const ref of references) {
+      if (!ref) {
+        continue;
+      }
+
+      if (typeof ref === 'function') {
+        ref(element);
+      } else {
+        ref.current = element;
+      }
+    }
+  };
+}
+

--- a/src/docs/views/migrate.mdx
+++ b/src/docs/views/migrate.mdx
@@ -4,6 +4,29 @@ import { Seo } from '../components/seo'
 
 # Migration Guide
 
+## v0.4 → v?.?
+
+We only have made some changes in `tiebreakers` in this release. FZF doesn't uses this option by default. So if you have not used a tiebreaker in your code, a version bump is all what you need!
+
+### `options.tiebreakers`
+
+- The third argument of tiebreaker has been changed from `options` to `selector`
+
+```diff
+- function byTrimmedLengthAsc(a, b, options) {
+-   return options.selector(a.item).trim().length - options.selector(b.item).trim().length;
++ function byTrimmedLengthAsc(a, b, selector) {
++   return selector(a.item).trim().length - selector(b.item).trim().length;
+  }
+
+
+const fzf = new Fzf(list, () => {
+  tiebreakers: [byTrimmedLengthAsc]
+})
+```
+
+- The behaviour of tiebreakers now matches with original FZF and with [other search solutions](https://youtu.be/7WQ00Y-80qs?t=3195). You can find more details about it in the updated section for tiebreakers.
+
 ## v0.3 → v0.4
 
 ### `options.maxResultItems`


### PR DESCRIPTION
~This fix is needed as updating link using React doesn't happen on its first render. Firefox listens for these anchor and scrolls related element into view but Chrome doesn't.~

Completely ignore this PR.