### PR TITLE
build: add windows compat layer in scripts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 14
+          - 16
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/scripts/fill-with-old-docs-win-compat.js
+++ b/scripts/fill-with-old-docs-win-compat.js
@@ -1,0 +1,111 @@
+const shell = require("shelljs");
+
+const currVerStr = require("../package.json").version;
+const currVerMajor = parseInt(currVerStr.split(".")[0], 10);
+const currVerMinor = parseInt(currVerStr.split(".")[1], 10);
+
+shell.rm("-r", "src/docs/old-docs");
+shell.mkdir("src/docs/old-docs");
+shell.touch("src/docs/old-docs/.gitkeep");
+
+const fillLegacyDocs = (verMajor, verMinor) => {
+  const nextCommitHash = shell
+    .exec(
+      `git log -S "\\"version\\": \\"${verMajor}.${verMinor}" --oneline -n 1 --branches HEAD -- package.json`,
+      {
+        silent: true,
+      }
+    )
+    .stdout.split(" ")[0];
+
+  const verStr = JSON.parse(
+    shell.exec(`git show "${nextCommitHash}^:./package.json"`, { silent: true })
+      .stdout
+  )["version"];
+
+  const fileContent = shell.exec(
+    `git show "${nextCommitHash}^:./src/views/docs.mdx"`,
+    { silent: true }
+  ).stdout;
+
+  const pkgFileContent = shell.exec(
+    `git show "${nextCommitHash}^:./package.json"`,
+    { silent: true }
+  ).stdout;
+
+  if (fileContent !== "") {
+    shell.mkdir("-p", `src/docs/old-docs/${verStr}/src/docs`);
+    shell
+      .ShellString(fileContent)
+      .to(`src/docs/old-docs/${verStr}/src/docs/docs.mdx`);
+    shell
+      .ShellString(pkgFileContent)
+      .to(`src/docs/old-docs/${verStr}/package.json`);
+    shell.cp(
+      "scripts/legacy-app-routes.tsx",
+      `src/docs/old-docs/${verStr}/src/docs/app-routes.tsx`
+    );
+  }
+};
+
+const fillDocs = (verMajor, verMinor) => {
+  if (verMajor === 0 && verMinor <= 3) {
+    if (verMinor < 3) return;
+
+    fillLegacyDocs(verMajor, verMinor);
+    return;
+  }
+
+  const nextCommitHash = shell
+    .exec(
+      `git log -S "\\"version\\": \\"${verMajor}.${verMinor}" --oneline -n 1 --branches HEAD -- package.json`,
+      {
+        silent: true,
+      }
+    )
+    .stdout.split(" ")[0];
+
+  const verStr = JSON.parse(
+    shell.exec(`git show "${nextCommitHash}^:./package.json"`, { silent: true })
+      .stdout
+  )["version"];
+
+  shell.exec(
+    `git worktree add -f "src/docs/old-docs/${verStr}" "${nextCommitHash}^"`,
+    { silent: true }
+  );
+
+  shell.rm(
+    "-r",
+    `src/docs/old-docs/${verStr}/vite*`,
+    `src/docs/old-docs/${verStr}/src/docs/typings`
+  );
+};
+
+for (let i = currVerMajor; i >= Math.max(0, currVerMajor - 2); i--) {
+  if (i === currVerMajor) {
+    for (let j = currVerMinor - 1; j >= Math.max(0, currVerMinor - 2); j--) {
+      fillDocs(i, j);
+    }
+  } else {
+    const nextCommitHash = shell
+      .exec(
+        `git log -S "\\"version\\": \\"${i}." --oneline -n 1 --branches HEAD -- package.json`,
+        {
+          silent: true,
+        }
+      )
+      .stdout.split(" ")[0];
+
+    const verStr = JSON.parse(
+      shell.exec(`git show "${nextCommitHash}^:./package.json"`, {
+        silent: true,
+      }).stdout
+    )["version"];
+    const verMinor = parseInt(verStr.split(".")[1], 10);
+
+    for (let j = verMinor; j >= Math.max(0, verMinor - 2); j--) {
+      fillDocs(i, j);
+    }
+  }
+}


### PR DESCRIPTION
Before this PR, on Windows when one builds and serves the docs, they couldn't see docs for the older versions. This used to happen because `shelljs` in Windows runs command prompt, which requires more parts of the command string to be wrapped in double quotes. 

This PR tries to achieve the above without adding maintenance burden. It is able to do so by copying scripts and making necessary changes for them to run on Windows. While it sounds counter to what we are trying to achieve, this decision seems correct as a readable code is a maintainable one. 

This PR also upgrades pipeline Node.js version to v16 which also makes this PR a continuation of https://github.com/ajitid/fzf-for-js/pull/89.