### PR TITLE
chore: update lockfile to reflect new npm version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,10 @@
         "vite": "^2.3.8",
         "vite-plugin-babel-macros": "^1.0.5",
         "vite-plugin-mdx": "^3.5.6"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@types/react-dom": "^17.0.0",
         "@vitejs/plugin-react-refresh": "^1.3.1",
         "autoprefixer": "^10.2.6",
-        "comlink": "^4.3.1",
         "glob": "^7.1.7",
         "history": "^5.0.0",
         "jest": "^27.0.6",
@@ -2369,12 +2368,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/comlink": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.1.tgz",
-      "integrity": "sha512-+YbhUdNrpBZggBAHWcgQMLPLH1KDF3wJpeqrCKieWQ8RL7atmgsgTQko1XEBK6PsecfopWNntopJ+ByYG1lRaA==",
-      "dev": true
     },
     "node_modules/comma-separated-tokens": {
       "version": "1.0.8",
@@ -9982,12 +9975,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "comlink": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.1.tgz",
-      "integrity": "sha512-+YbhUdNrpBZggBAHWcgQMLPLH1KDF3wJpeqrCKieWQ8RL7atmgsgTQko1XEBK6PsecfopWNntopJ+ByYG1lRaA==",
-      "dev": true
     },
     "comma-separated-tokens": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@types/react-dom": "^17.0.0",
     "@vitejs/plugin-react-refresh": "^1.3.1",
     "autoprefixer": "^10.2.6",
-    "comlink": "^4.3.1",
     "glob": "^7.1.7",
     "history": "^5.0.0",
     "jest": "^27.0.6",


### PR DESCRIPTION
Continuation of https://github.com/ajitid/fzf-for-js/pull/89. This PR removes unneeded comlink package and stores engine info (Node.js and NPM version) in the lockfile.