### PR TITLE
fix!: remove engine info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,10 +39,6 @@
         "vite": "^2.3.8",
         "vite-plugin-babel-macros": "^1.0.5",
         "vite-plugin-mdx": "^3.5.6"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -50,10 +50,6 @@
   "types": "./dist/types/main.d.ts",
   "===== HINTING =====": "",
   "sideEffects": false,
-  "engines": {
-    "npm": ">=8.0.0",
-    "node": ">=16.0.0"
-  },
   "===== DEPS =====": "",
   "devDependencies": {
     "@mdx-js/mdx": "^1.6.22",


### PR DESCRIPTION
It was mistakenly assumed that specifying `engines` in `package.json` would notify people who would be developing fzf and not to the end users themselves. Rolling back this change.