### PR TITLE
Add `types` exports field for TypeScript ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "module": "./dist/fzf.es.js",
   "exports": {
     ".": {
+      "types": "./dist/types/main.d.ts",
       "import": "./dist/fzf.es.js",
       "require": "./dist/fzf.umd.js"
     }


### PR DESCRIPTION
This is [required](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing) for TypeScript to work under `"module": "node16"`, see https://github.com//microsoft/TypeScript/issues/47792.