### PR TITLE
export type SyncOptionsTuple

### DIFF
--- a/src/lib/main.ts
+++ b/src/lib/main.ts
@@ -8,7 +8,7 @@ import type {
 } from "./finders";
 import type { SyncOptions, AsyncOptions } from "./types";
 
-export type { FzfResultItem, Selector, Tiebreaker } from "./types";
+export type { FzfResultItem, Selector, Tiebreaker, SyncOptionsTuple } from "./types";
 export * from "./matchers";
 export * from "./tiebreakers";
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -152,3 +152,5 @@ export type AsyncOptions<U> = BaseOptions<U> & {
     token: Token
   ) => Promise<FzfResultItem<U>[]>;
 };
+
+export type { SyncOptionsTuple } from "./finders";


### PR DESCRIPTION
We use this type at work and currently have to import it as:

```ts
import type { SyncOptionsTuple } from 'node_modules/fzf/dist/types/finders'
```

There could be more improvements to the type exports, but for now this would resolve this issue.